### PR TITLE
Add Windows to macOS port direction to juce-dev port command

### DIFF
--- a/plugins/juce-dev/commands/port.md
+++ b/plugins/juce-dev/commands/port.md
@@ -1,5 +1,5 @@
 ---
-description: Port an existing macOS JUCE plugin project to Windows and/or Linux
+description: Port a JUCE plugin project between macOS, Windows, and Linux
 argument-hint: "<platform> [--audit-only] [--vm <alias>] [--test-ci]"
 allowed-tools:
   - Read
@@ -12,16 +12,17 @@ allowed-tools:
   - Agent
 ---
 
-# Port JUCE Plugin to Windows/Linux
+# Port JUCE Plugin Cross-Platform
 
-Port an existing macOS JUCE plugin project to Windows and/or Linux. Scans for platform-specific code, generates a plan, applies changes, and optionally tests on a VM or via CI.
+Port an existing JUCE plugin project to another platform. Supports porting in any direction: macOS → Windows/Linux, or Windows → macOS/Linux. Scans for platform-specific code, generates a plan, applies changes, and optionally tests on a VM or via CI.
 
 ## Arguments
 
-**Platform** (required):
-- `windows` — Audit and port for Windows (MSVC + Ninja, D3D11)
-- `linux` — Audit and port for Linux (Clang + Ninja, Vulkan)
-- `all` — Audit and port for both platforms
+**Platform** (required) — the **target** platform you're porting TO:
+- `windows` — Port to Windows (MSVC + Ninja, D3D11)
+- `linux` — Port to Linux (Clang + Ninja, Vulkan)
+- `macos` — Port to macOS (Apple Clang + Xcode/Ninja, Metal)
+- `all` — Port to all other platforms
 
 **Options:**
 - `--audit-only` — Just scan and report issues, don't make changes
@@ -30,7 +31,7 @@ Port an existing macOS JUCE plugin project to Windows and/or Linux. Scans for pl
 
 ## Implementation
 
-### Stage 0: Detect Project
+### Stage 0: Detect Project and Source Platform
 
 Verify this is a JUCE-Plugin-Starter project:
 
@@ -41,6 +42,31 @@ test -f .env || test -f .env.example || { echo "WARNING: No .env file found"; }
 test -d scripts/ || { echo "WARNING: No scripts/ directory"; }
 test -d Source/ || { echo "ERROR: No Source/ directory"; exit 1; }
 ```
+
+**Detect the source platform** (what the project was built on):
+
+```bash
+# Check for macOS-origin indicators
+has_mm_files=$(find Source/ -name "*.mm" 2>/dev/null | head -1)
+has_xcode_script=$(test -f scripts/generate_and_open_xcode.sh && echo "yes")
+has_build_sh=$(test -f scripts/build.sh && echo "yes")
+
+# Check for Windows-origin indicators
+has_ps1=$(test -f scripts/build.ps1 && echo "yes")
+has_msvc_cmake=$(grep -l "if(MSVC)" CMakeLists.txt 2>/dev/null)
+has_azure_signing=$(grep -l "AZURE_TENANT_ID" .env 2>/dev/null || grep -l "AZURE_TENANT_ID" .env.example 2>/dev/null)
+has_inno_setup=$(grep -rl "Inno Setup\|\.iss" scripts/ 2>/dev/null | head -1)
+```
+
+Determine source platform:
+- If `.mm` files, Xcode script, or macOS post-build scripts exist → **macOS-origin**
+- If `build.ps1` exists without `build.sh`, or Azure signing vars are set, or Inno Setup references → **Windows-origin**
+- If both → **hybrid** (already partially cross-platform)
+- If neither → ask the user
+
+Validate the port direction makes sense:
+- Porting macOS → macOS = error ("Already a macOS project")
+- Porting Windows → Windows = error ("Already a Windows project")
 
 Read `.env` to understand the project:
 - `PROJECT_NAME` — plugin name
@@ -57,19 +83,21 @@ git status --short
 
 Scan the project for platform-specific dependencies and produce a structured report.
 
-#### What to scan
-
 **IMPORTANT: Visage is fully cross-platform.** It uses bgfx for rendering:
 - macOS: Metal
 - Windows: Direct3D11
 - Linux: Vulkan
 - Web/Emscripten: WebGL
 
-Do NOT flag Visage as macOS-only. It compiles and runs on all platforms. The JuceVisageBridge may need platform-specific windowing code (NSView on macOS, HWND on Windows, X11 on Linux), but Visage itself works everywhere.
+Do NOT flag Visage as platform-only. It compiles and runs on all platforms. The JuceVisageBridge may need platform-specific windowing code (NSView on macOS, HWND on Windows, X11 on Linux), but Visage itself works everywhere.
+
+---
+
+#### If porting TO Windows or Linux (from macOS)
 
 **Source files (*.cpp, *.h, *.mm):**
 
-Scan for these platform-specific patterns:
+Scan for these macOS-specific patterns:
 
 | Pattern | Severity | Description |
 |---------|----------|-------------|
@@ -128,8 +156,114 @@ Check for:
 - Need `.exe` versions for Windows, Linux binaries for Linux
 - Flag as needing platform-specific packaging, not code changes
 
+---
+
+#### If porting TO macOS (from Windows)
+
+**Source files (*.cpp, *.h):**
+
+Scan for these Windows-specific patterns:
+
+| Pattern | Severity | Description | macOS Fix |
+|---------|----------|-------------|-----------|
+| `#include <windows.h>` | HIGH | Windows API header | Guard with `#if JUCE_WINDOWS` or use JUCE abstractions |
+| `#include <d3d11.h>`, `<dxgi.h>` | HIGH | Direct3D headers | Guard — macOS uses Metal via Visage/bgfx |
+| `#include <wrl/client.h>` | HIGH | Windows Runtime C++ (COM) | Guard with `#if JUCE_WINDOWS` |
+| `#include <shlobj.h>`, `<shellapi.h>` | HIGH | Windows Shell API | Use JUCE `File::getSpecialLocation()` |
+| `#include <combaseapi.h>`, `<oleauto.h>` | MEDIUM | COM automation | Guard with `#if JUCE_WINDOWS` |
+| `#include <winsock2.h>` | MEDIUM | Windows sockets | Use JUCE `URL`/`StreamingSocket` |
+| `#include <winreg.h>` | MEDIUM | Windows registry | Use JUCE `PropertiesFile` |
+| `#include <mmsystem.h>` | MEDIUM | Windows multimedia | JUCE abstracts audio/MIDI |
+| `#include <psapi.h>`, `<tlhelp32.h>` | LOW | Process APIs | Guard with `#if JUCE_WINDOWS` |
+| `HWND`, `HINSTANCE`, `HMODULE`, `HKEY` | HIGH | Win32 handle types | Guard with `#if JUCE_WINDOWS` |
+| `LPWSTR`, `LPCWSTR`, `DWORD`, `BOOL` | MEDIUM | Windows integer/string types | Guard with `#if JUCE_WINDOWS` |
+| `CreateWindow`, `RegisterClass`, `DefWindowProc` | HIGH | Win32 windowing | Use JUCE component system |
+| `PostMessage`, `SendMessage` | MEDIUM | Win32 message queue | Use JUCE `MessageManager` |
+| `CoInitialize`, `CoCreateInstance` | HIGH | COM initialization | Guard — not needed on macOS |
+| `IUnknown`, `IDispatch`, `IID_PPV_ARGS` | HIGH | COM interfaces | Guard — Windows-only |
+| `HRESULT`, `SUCCEEDED`, `FAILED` | MEDIUM | COM error handling | Guard with `#if JUCE_WINDOWS` |
+| `LoadLibrary`, `GetProcAddress` | MEDIUM | DLL loading | Use `dlopen`/`dlsym` or JUCE `DynamicLibrary` |
+| `RegOpenKey`, `RegQueryValue` | MEDIUM | Registry access | Use JUCE `PropertiesFile` |
+| `QueryPerformanceCounter` | LOW | High-precision timer | Use `std::chrono` or JUCE `Time` |
+| `ShellExecute`, `CreateProcess` | MEDIUM | Process execution | Use JUCE `ChildProcess` |
+| `OutputDebugString` | LOW | Debug output | Use `DBG()` or `juce::Logger` |
+| `GetModuleHandle` | MEDIUM | Module handle | Guard with `#if JUCE_WINDOWS` |
+| `WaitForSingleObject`, `CreateEvent` | MEDIUM | Sync primitives | Use `std::mutex`/`std::condition_variable` |
+| `__declspec(dllexport/dllimport)` | HIGH | MSVC DLL export | Use `JUCE_API` or cross-platform macro |
+| `#pragma comment(lib, ...)` | HIGH | MSVC linker directive | Use CMake `target_link_libraries` |
+| `#pragma warning(disable:...)` | MEDIUM | MSVC warning suppression | Guard with `#if _MSC_VER` |
+| `%APPDATA%`, `%LOCALAPPDATA%`, `%USERPROFILE%` | MEDIUM | Windows env paths | Use JUCE `File::getSpecialLocation()` |
+| `C:\` hardcoded paths | MEDIUM | Windows paths | Use `juce::File` for path construction |
+| `.dll` references | LOW | Windows dynamic libs | `.dylib` on macOS |
+| `.exe` references | LOW | Windows executables | No extension on macOS |
+| `ID3D11Device`, `IDXGISwapChain` | HIGH | Direct3D interfaces | Guard — Visage handles this via bgfx |
+| `D3D11_*_DESC` structures | MEDIUM | Direct3D descriptors | Guard with `#if JUCE_WINDOWS` |
+
+Also note already-handled patterns (no action needed):
+- `#if JUCE_WINDOWS` / `#ifdef _WIN32` / `#ifdef _MSC_VER` — already platform-guarded
+- `#if ! JUCE_MAC` — already handled
+- `NOMINMAX`, `WIN32_LEAN_AND_MEAN` — compile definitions, usually guarded
+
+**Windows resource files:**
+- `.rc` files — Windows resource files (not needed on macOS, skip)
+- `.manifest` files — Windows assembly manifests (not needed on macOS, skip)
+
+**CMakeLists.txt:**
+
+Check for:
+- `if(MSVC)` blocks — need `if(APPLE)` equivalents added
+- `if(WIN32)` blocks — verify macOS alternatives exist
+- `$ENV{USERPROFILE}` — ensure `$ENV{HOME}` fallback exists
+- `CMAKE_MSVC_DEBUG_INFORMATION_FORMAT` — macOS doesn't need this
+- Missing `CMAKE_OSX_DEPLOYMENT_TARGET` — needs to be added (e.g., 10.15+)
+- Missing `CMAKE_OSX_ARCHITECTURES` — add `arm64;x86_64` for universal binaries
+- Plugin FORMATS — AU/AUv3 need to be added inside `if(APPLE)` block
+- Missing macOS frameworks — CoreAudio, CoreMIDI, AppKit links
+- Post-build codesign steps — need `if(APPLE)` block for signing
+- `.mm` files — may need to be added for macOS-specific bridging
+- Visage `add_subdirectory` — should already work (no changes needed)
+- MSVC flags (`/bigobj`, `/permissive-`) — guard with `if(MSVC)` if not already
+- `file(TO_CMAKE_PATH ...)` — still useful, no need to remove
+
+**Build scripts:**
+- `build.sh` — exists? If not, copy from JUCE-Plugin-Starter template
+- `generate_and_open_xcode.sh` — exists? If not, copy from template
+- `build.ps1` — Windows-only, OK to keep for Windows builds
+- `scripts/post_build.sh` — macOS code signing script, may need to be added
+
+**Installer and packaging:**
+- Inno Setup `.iss` files — Windows-only installer, not needed on macOS
+- Need macOS packaging: `.pkg` or `.dmg` creation (via `pkgbuild`/`productbuild`)
+- `installer_binaries/` — need macOS versions of bundled tools
+
+**External dependencies:**
+- Visage: cross-platform — works on macOS via Metal (no changes needed)
+- WinSparkle: Windows-only auto-updater — replace with Sparkle on macOS, guard with platform conditional
+- FetchContent deps (JUCE, CLAP, Catch2): cross-platform, should work
+- Any `.lib` static libraries — need `.a` equivalents for macOS
+
+**macOS-specific additions needed:**
+
+| Addition | Priority | Description |
+|----------|----------|-------------|
+| AU/AUv3 plugin format | HIGH | macOS-only formats — Logic Pro requires AU |
+| Code signing setup | HIGH | Developer ID cert for distribution |
+| Notarization setup | HIGH | Required for macOS distribution outside App Store |
+| `CMAKE_OSX_DEPLOYMENT_TARGET` | HIGH | Minimum macOS version (e.g., 10.15) |
+| `CMAKE_OSX_ARCHITECTURES` | HIGH | `arm64;x86_64` for Apple Silicon + Intel |
+| `build.sh` script | HIGH | macOS/Linux build script |
+| `generate_and_open_xcode.sh` | MEDIUM | Convenience script for Xcode development |
+| macOS framework links | MEDIUM | CoreAudio, CoreMIDI, AppKit in CMakeLists.txt |
+| `post_build.sh` | MEDIUM | AU validation, codesign, plugin install |
+| `.env` macOS variables | MEDIUM | `APP_CERT`, `INSTALLER_CERT`, `TEAM_ID`, `APPLE_ID` |
+| Bundle Info.plist | LOW | JUCE generates this, but verify it's correct |
+
+---
+
+#### Common checks (both directions)
+
 **Configuration:**
-- `.env` — any platform-specific values
+- `.env` — any platform-specific values that need counterparts
 - `.github/workflows/` — CI for target platform exists?
 
 #### Audit Output Format
@@ -137,29 +271,37 @@ Check for:
 Present findings as a structured table:
 
 ```
-## Port Audit: <ProjectName> -> <Platform>
+## Port Audit: <ProjectName> (<SourcePlatform> → <TargetPlatform>)
 
 ### Issues Found
 
 | # | File | Line | Issue | Severity | Fix |
 |---|------|------|-------|----------|-----|
 | 1 | Source/Foo.mm | - | Objective-C++ file | HIGH | Wrap in if(APPLE) in CMakeLists.txt |
-| 2 | Source/Bar.cpp | 45 | #include <dlfcn.h> | LOW | Add #if ! JUCE_WINDOWS guard |
-| 3 | CMakeLists.txt | 50 | No MSVC flags | HIGH | Add if(MSVC) block |
-| 4 | scripts/ | - | No build.ps1 | HIGH | Copy from template |
+| 2 | Source/Bar.cpp | 45 | #include <windows.h> | HIGH | Add #if JUCE_WINDOWS guard |
+| 3 | CMakeLists.txt | 50 | No if(APPLE) block | HIGH | Add macOS platform conditionals |
+| 4 | scripts/ | - | No build.sh | HIGH | Copy from template |
 
 ### Already Cross-Platform
 - Source/PluginProcessor.cpp — no platform-specific code
 - Source/DSP/*.cpp — pure C++, portable
-- external/visage — fully cross-platform (D3D11 on Windows)
+- external/visage — fully cross-platform (Metal on macOS, D3D11 on Windows)
 
 ### External Dependencies
 | Dependency | Status | Notes |
 |-----------|--------|-------|
 | JUCE | Cross-platform | Via FetchContent |
-| Visage | Cross-platform | D3D11 on Windows, Vulkan on Linux |
-| Essentia | macOS-only prebuilt | Need Windows/Linux builds |
-| Sparkle | macOS-only | Skip on other platforms |
+| Visage | Cross-platform | Metal on macOS, D3D11 on Windows, Vulkan on Linux |
+| Essentia | Needs check | May have platform-specific prebuilt libs |
+| WinSparkle | Windows-only | Replace with Sparkle on macOS |
+
+### macOS Additions Needed (for Windows → macOS port)
+| Addition | Priority |
+|----------|----------|
+| AU/AUv3 format support | HIGH |
+| Code signing & notarization | HIGH |
+| Universal binary (arm64 + x86_64) | HIGH |
+| build.sh script | HIGH |
 
 ### Bundled Binaries (need platform versions)
 | Binary | macOS | Windows | Linux |
@@ -193,10 +335,14 @@ options:
 Create a feature branch and apply changes:
 
 ```bash
-git checkout -b port/<platform>   # or feature/windows-build, etc.
+git checkout -b port/<platform>   # e.g., port/windows, port/macos, port/linux
 ```
 
-Apply fixes in order of severity (HIGH first):
+Apply fixes in order of severity (HIGH first).
+
+---
+
+#### If porting TO Windows or Linux (from macOS)
 
 1. **CMakeLists.txt platform conditionals** — this is the most impactful change
    - Add FETCHCONTENT_BASE_DIR Windows path handling
@@ -220,6 +366,59 @@ Apply fixes in order of severity (HIGH first):
 4. **External dependencies** — handle platform-specific deps
    - Guard macOS-only deps in CMakeLists.txt
    - Note which deps need cross-platform builds (report, don't fix)
+
+---
+
+#### If porting TO macOS (from Windows)
+
+1. **CMakeLists.txt platform conditionals** — most impactful change
+   - Add `CMAKE_OSX_DEPLOYMENT_TARGET` (e.g., `10.15` or as set in `.env`)
+   - Add `CMAKE_OSX_ARCHITECTURES` (`arm64;x86_64` for universal binaries)
+   - Add `if(APPLE)` block for AU/AUv3 plugin formats alongside existing VST3/CLAP/Standalone
+   - Guard MSVC-specific flags (`/bigobj`, `/permissive-`, `CMAKE_MSVC_DEBUG_INFORMATION_FORMAT`) with `if(MSVC)` if not already guarded
+   - Add macOS framework links inside `if(APPLE)`: `-framework CoreAudio`, `-framework CoreMIDI`, `-framework AppKit`
+   - Add `if(APPLE)` post-build block for codesign and AU validation
+   - Ensure `$ENV{HOME}` fallback exists alongside `$ENV{USERPROFILE}` for FETCHCONTENT_BASE_DIR
+   - Ensure Visage `add_subdirectory` is NOT guarded (it's cross-platform — Metal on macOS)
+
+2. **Source code platform guards** — fix compile errors
+   - Add `#if JUCE_WINDOWS` around Windows-only headers (`<windows.h>`, `<d3d11.h>`, `<shlobj.h>`, etc.)
+   - Add `#if JUCE_WINDOWS` around Win32 API usage (`CreateWindow`, `HWND`, COM calls)
+   - Add `#if JUCE_WINDOWS` around DirectX code (Visage handles D3D→Metal via bgfx, but direct D3D calls need guarding)
+   - Guard `__declspec` attributes with `#if _MSC_VER`
+   - Guard `#pragma comment(lib, ...)` with `#if _MSC_VER`
+   - Guard `#pragma warning(disable:...)` with `#if _MSC_VER`
+   - Replace Windows path APIs with JUCE abstractions (`File::getSpecialLocation()`)
+   - Replace registry access (`RegOpenKey`, etc.) with JUCE `PropertiesFile`
+   - Replace `LoadLibrary`/`GetProcAddress` with JUCE `DynamicLibrary`
+   - Replace `OutputDebugString` with `DBG()` or `juce::Logger`
+
+3. **Build scripts** — ensure macOS can build
+   - Copy `build.sh` from JUCE-Plugin-Starter template if missing
+   - Copy `generate_and_open_xcode.sh` from template if missing
+   - Copy `post_build.sh` from template if missing (codesign + AU validation)
+   - Verify `build.sh` has macOS BUILD_PLATFORM detection (`Darwin` case in `uname -s`)
+
+4. **macOS developer settings** — add to `.env`
+   - Add `OSX_DEPLOYMENT_TARGET` if missing (e.g., `10.15`)
+   - Add `OSX_ARCHITECTURES` if missing (e.g., `arm64;x86_64`)
+   - Add code signing variables: `APP_CERT`, `INSTALLER_CERT`, `TEAM_ID`
+   - Add notarization variables: `APPLE_ID`, `APP_SPECIFIC_PASSWORD`
+   - Note: these can be left empty — build will work unsigned for development
+
+5. **External dependencies** — handle platform-specific deps
+   - Guard Windows-only deps (WinSparkle) with `if(WIN32)` in CMakeLists.txt
+   - Add Sparkle for macOS auto-update if WinSparkle was used, inside `if(APPLE)`
+   - Note which deps need macOS builds (report, don't fix)
+   - Check `.lib` static libraries — may need `.a` equivalents
+
+6. **Plugin format setup** — AU/AUv3 specific
+   - AU requires correct manufacturer code (4-char) in CMake `PLUGIN_MANUFACTURER_CODE`
+   - AUv3 requires App Sandbox entitlements
+   - After build, validate AU with: `auval -v aufx <plugin_code> <manufacturer_code>`
+   - Plugin install paths: `~/Library/Audio/Plug-Ins/Components/` (AU), `~/Library/Audio/Plug-Ins/VST3/` (VST3)
+
+---
 
 After each change, commit with a descriptive message.
 
@@ -247,9 +446,7 @@ If VM testing is selected and `--vm <alias>` is provided:
 
 1. Push the branch to remote
 2. SSH to VM, pull the branch
-3. Run the build:
-   - Windows: Create a `.bat` file that calls VsDevCmd.bat then cmake (avoid quoting issues over SSH)
-   - Linux: Run `./scripts/build.sh all` directly
+3. Run the build (platform-dependent — see below)
 4. Report results
 5. If failures: analyze errors, fix locally, push, repeat
 
@@ -269,12 +466,44 @@ BATEOF
 ssh <vm> "<build.bat path>"
 ```
 
+**macOS VM build pattern:**
+```bash
+# Build on macOS VM
+ssh <vm> "cd <project_path> && git pull origin port/macos"
+
+# Option 1: Use build.sh
+ssh <vm> "cd <project_path> && ./scripts/build.sh all"
+
+# Option 2: Use CMake directly (Ninja)
+ssh <vm> "cd <project_path> && cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=Release && cmake --build build --config Release"
+
+# Option 3: Generate Xcode project
+ssh <vm> "cd <project_path> && cmake -B build-xcode -G Xcode && cmake --build build-xcode --config Release"
+
+# Validate AU plugin (after successful build)
+ssh <vm> "auval -v aufx <plugin_code> <manufacturer_code>"
+
+# Check installed plugins
+ssh <vm> "ls ~/Library/Audio/Plug-Ins/Components/ | grep <ProjectName>"
+ssh <vm> "ls ~/Library/Audio/Plug-Ins/VST3/ | grep <ProjectName>"
+```
+
+**Linux VM build pattern:**
+```bash
+ssh <vm> "cd <project_path> && git pull origin port/linux && ./scripts/build.sh all"
+```
+
 **Key learnings from cross-platform porting:**
 - Read `docs/cross-platform-learnings.md` if it exists — it has known gotchas
 - Windows ARM64 VMs may have x86-64 emulation issues with some tools
 - JUCE cache at `~/.juce_cache/` is generator-specific — clear when switching
 - Use `VsDevCmd.bat` not `Enter-VsDevShell` (latter changes CWD)
 - `cmd /c` with nested quotes fails over SSH — use `.bat` scripts
+- macOS: Xcode/Clang is stricter than MSVC — narrowing conversions, implicit type casts will error
+- macOS: Universal binaries (arm64 + x86_64) require ALL dependencies to be built for both architectures
+- macOS: `killall -9 AudioComponentRegistrar` forces re-scan of AU plugins after install
+- macOS: `auval -a` lists all registered AudioUnits — use to verify plugin shows up
+- macOS: Hardened Runtime must be enabled for notarization (entitlements.plist)
 
 #### CI Testing
 
@@ -293,19 +522,26 @@ VM details are stored in `.claude/juce-dev.local.md`:
 vms:
   windows:
     ssh: win
+    platform: windows
     project_path: "C:\\Users\\daniel\\Code\\ProjectName"
     shell: powershell
   linux:
     ssh: linux
+    platform: linux
     project_path: /home/daniel/Code/ProjectName
     shell: bash
+  macos:
+    ssh: mac
+    platform: macos
+    project_path: /Users/daniel/Code/ProjectName
+    shell: zsh
 ---
 ```
 
 If no VM config exists and `--vm` is used, ask the user:
 
 ```
-question: "What's your SSH alias for the Windows VM?"
+question: "What's your SSH alias for the <Platform> VM?"
 ```
 
 Save it to `.claude/juce-dev.local.md` for future use.
@@ -315,12 +551,18 @@ Save it to `.claude/juce-dev.local.md` for future use.
 Before executing, check if `docs/cross-platform-learnings.md` exists in the project. It contains known gotchas and solutions discovered during previous porting work.
 
 Key facts:
-- **Visage is fully cross-platform** (Metal/D3D11/Vulkan/WebGL via bgfx). NEVER skip Visage on non-macOS platforms.
-- **bgfx shaderc.exe** bundled with Visage is x86-64 — may crash on ARM64 Windows. Need ARM64 build or Windows SDK installed.
+- **Visage is fully cross-platform** (Metal/D3D11/Vulkan/WebGL via bgfx). NEVER skip Visage on any platform.
+- **bgfx shaderc.exe** bundled with Visage is x86-64 — may crash on ARM64 Windows. Need ARM64 build or Windows SDK installed. macOS universal binary works on Apple Silicon.
 - **Windows SDK** is needed for D3D11 shader compilation (fxc.exe/dxc.exe).
 - **FETCHCONTENT_BASE_DIR** backslashes on Windows cause CMake escape errors — use `file(TO_CMAKE_PATH ...)`.
 - **`sed -i`** differs between macOS (`sed -i ''`) and Linux (`sed -i`) — use platform detection.
 - **AU/AUv3** formats are macOS-only — guard with `if(APPLE)` in CMakeLists.txt.
 - **Essentia** may have macOS-only prebuilt libs — check for cross-platform builds.
 - **Sparkle** auto-update is macOS-only — guard with `if(APPLE)`.
+- **WinSparkle** auto-update is Windows-only — guard with `if(WIN32)`.
 - **Bundled binaries** (yt-dlp, ffmpeg, etc.) are cross-platform but need platform-specific builds.
+- **Xcode/Clang strictness** — code that compiles on MSVC may fail on Clang due to stricter narrowing conversion and implicit cast rules.
+- **Universal binaries** — macOS plugins should ship arm64 + x86_64. Set `CMAKE_OSX_ARCHITECTURES`.
+- **Notarization** — required for macOS distribution. Needs Hardened Runtime, Developer ID cert, and `xcrun notarytool`.
+- **Inno Setup** — Windows-only installer. macOS uses `pkgbuild`/`productbuild` or DMG.
+- **Azure Trusted Signing** — Windows code signing service. macOS uses Apple Developer ID certificates in Keychain.

--- a/plugins/juce-dev/index.html
+++ b/plugins/juce-dev/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>juce-dev | Plugin for Claude Code</title>
-    <meta name="description" content="A Claude Code plugin for the full JUCE audio plugin lifecycle — create, build, test, sign, publish, and port macOS audio plugins to Windows and Linux.">
+    <meta name="description" content="A Claude Code plugin for the full JUCE audio plugin lifecycle — create, build, test, sign, publish, and port audio plugins cross-platform between macOS, Windows, and Linux.">
 
     <!-- Open Graph (iMessage, Slack, Discord, etc.) -->
     <meta property="og:title" content="juce-dev">
@@ -483,7 +483,7 @@
                 <div class="col-right">
                     <p>Starting a new audio plugin usually means wiring up build systems, configuring code signing, setting up project identifiers, and writing boilerplate. It's tedious before you write a single line of audio code.</p>
                     <p><strong>juce-dev handles all of that.</strong> Give it a name, confirm your developer settings, pick your options, and you get a project that compiles immediately. If it's your first time, it checks your tools and walks you through setup.</p>
-                    <p><strong>Go cross-platform:</strong> Start on macOS and port to Windows when you're ready (Linux coming soon). The port command scans your macOS code for platform-specific dependencies, shows you exactly what needs to change, and applies the fixes — including building and testing on a remote Windows VM over SSH.</p>
+                    <p><strong>Go cross-platform:</strong> Port between macOS and Windows in either direction (Linux coming soon). The port command scans your project for platform-specific code, shows you exactly what needs to change, and applies the fixes — including building and testing on a remote VM over SSH. Started on Windows and want to ship on macOS? It handles that too, adding AU/AUv3 support, code signing, universal binaries, and everything else macOS needs.</p>
                     <p><strong>Context-aware assistance:</strong> If you add Visage GPU UI to your project, a bundled <a href="../../skills/claude/juce-visage/">juce-visage skill</a> automatically provides Claude with deep knowledge of Metal view embedding, event bridging, keyboard handling in DAW hosts, and more. No Visage? The skill stays out of the way — it only activates when relevant.</p>
                     <p>Want to go further? Use <a href="https://www.generouscorp.com/generous-corp-marketplace/plugins/chainer/">Chainer</a> to describe what your plugin should do and let Claude build it for you.</p>
                 </div>
@@ -506,7 +506,7 @@
                         <li>Optional iOS/iPadOS app target with auto-detected UI mode</li>
                         <li>Bundled <a href="../../skills/claude/juce-visage/">juce-visage skill</a> — activates only when working on Visage UI</li>
                         <li>Optional crash reporting for your users</li>
-                        <li>Port to Windows — audit macOS-specific code, fix, and test on a remote VM (Linux coming soon)</li>
+                        <li>Port between macOS and Windows — audit platform-specific code, fix, and test on a remote VM (Linux coming soon)</li>
                         <li>Git repo initialized, GitHub repo created if you want</li>
                         <li>Checks your dev environment and installs missing tools</li>
                         <li>Developer settings saved — next project is even faster</li>
@@ -640,17 +640,21 @@
                 </div>
                 <div class="col-left">
                     <div class="workflow-card">
-                        <div class="workflow-title">Port to Windows <span style="font-size: 0.75rem; color: var(--gray); font-weight: normal;">(Linux coming soon)</span></div>
+                        <div class="workflow-title">Port cross-platform <span style="font-size: 0.75rem; color: var(--gray); font-weight: normal;">(Linux coming soon)</span></div>
                         <div class="code-block-wrapper">
                             <button class="copy-btn" onclick="copyCode(this)">Copy</button>
                             <div class="code-block"><span class="code-prompt">/</span>juce-dev:port windows --vm win</div>
                         </div>
+                        <div style="margin-top: 0.5rem;" class="code-block-wrapper">
+                            <button class="copy-btn" onclick="copyCode(this)">Copy</button>
+                            <div class="code-block"><span class="code-prompt">/</span>juce-dev:port macos --vm mac</div>
+                        </div>
                         <div class="workflow-desc">
-                            Audit macOS-specific code, fix, build, and test on a remote VM.
+                            Audit platform-specific code, fix, build, and test on a remote VM. Works in both directions.
                             <span class="learn-more" onclick="toggleDetails(this)">What happens</span>
                         </div>
                         <div class="details">
-                            Scans your macOS project for platform-specific code (Objective-C++ files, Cocoa imports, Apple framework dependencies, macOS-specific paths), generates a severity-ranked report, and applies cross-platform fixes (CMake conditionals, <code>#if JUCE_MAC</code> guards, MSVC flags). Can then SSH to your Windows VM to build and test. Currently ports from macOS → Windows. Visage is fully cross-platform (D3D11 on Windows) and is never flagged.
+                            Scans your project for platform-specific code and generates a severity-ranked report. <strong>macOS → Windows:</strong> finds Objective-C++ files, Cocoa imports, Apple frameworks, macOS paths; applies CMake conditionals, <code>#if JUCE_MAC</code> guards, MSVC flags. <strong>Windows → macOS:</strong> finds Win32 API calls, COM/DirectX code, MSVC pragmas, Windows paths; adds AU/AUv3 formats, universal binary config, code signing, macOS build scripts. Can SSH to your target VM to build and test. Visage is fully cross-platform and is never flagged.
                         </div>
                     </div>
                 </div>
@@ -742,13 +746,17 @@
 <span class="code-prompt">/</span>juce-dev:build publish
 
 
-<span class="code-comment"># ── Port (macOS → Windows) ──────────────────────────</span>
+<span class="code-comment"># ── Port (cross-platform) ───────────────────────────</span>
 
-<span class="code-comment"># Audit macOS project for Windows compatibility</span>
+<span class="code-comment"># Audit project for target platform compatibility</span>
 <span class="code-prompt">/</span>juce-dev:port windows --audit-only
+<span class="code-prompt">/</span>juce-dev:port macos --audit-only
 
-<span class="code-comment"># Port to Windows and test on a VM</span>
+<span class="code-comment"># Port macOS → Windows and test on a VM</span>
 <span class="code-prompt">/</span>juce-dev:port windows --vm win
+
+<span class="code-comment"># Port Windows → macOS and test on a VM</span>
+<span class="code-prompt">/</span>juce-dev:port macos --vm mac
 
 <span class="code-comment"># Port and trigger GitHub Actions CI</span>
 <span class="code-prompt">/</span>juce-dev:port windows --test-ci
@@ -759,8 +767,9 @@
 <span class="code-comment"># Show project config, features, and VMs</span>
 <span class="code-prompt">/</span>juce-dev:status
 
-<span class="code-comment"># Add a Windows VM for cross-platform builds</span>
+<span class="code-comment"># Add VMs for cross-platform builds</span>
 <span class="code-prompt">/</span>juce-dev:vm add win win-ssh windows
+<span class="code-prompt">/</span>juce-dev:vm add mac mac-ssh macos
 
 <span class="code-comment"># List configured VMs</span>
 <span class="code-prompt">/</span>juce-dev:vm list
@@ -932,26 +941,26 @@ rm -rf tmp-juce-visage</div>
                     <div class="faq-item">
                         <div class="faq-question" onclick="toggleFaq(this)">Does this work on Windows or Linux?</div>
                         <div class="faq-answer">
-                            <p><strong>You develop on macOS, then port.</strong> The plugin runs in Claude Code on a Mac, where you create and build your plugin. When you're ready to go cross-platform, <code>/juce-dev:port windows</code> scans your macOS project for platform-specific code (Objective-C++, Cocoa imports, Apple frameworks, macOS paths), applies the fixes, and can build and test on a remote Windows VM over SSH. Linux support is coming soon.</p>
-                            <p>The <a href="https://github.com/danielraffel/JUCE-Plugin-Starter">JUCE-Plugin-Starter</a> template already includes cross-platform CMake configuration and a Windows build script (<code>build.ps1</code>). The port command handles your project-specific code — the things you add on top of the template.</p>
+                            <p><strong>Port in either direction between macOS and Windows.</strong> Started on macOS? Use <code>/juce-dev:port windows</code> to scan for macOS-specific code and apply Windows-compatible fixes. Started on Windows? Use <code>/juce-dev:port macos</code> to scan for Windows-specific code and add macOS support (AU/AUv3 formats, universal binaries, code signing, notarization). Both directions can build and test on a remote VM over SSH. Linux support is coming soon.</p>
+                            <p>The <a href="https://github.com/danielraffel/JUCE-Plugin-Starter">JUCE-Plugin-Starter</a> template already includes cross-platform CMake configuration, a macOS build script (<code>build.sh</code>), and a Windows build script (<code>build.ps1</code>). The port command handles your project-specific code — the things you add on top of the template.</p>
                             <p>The build command (<code>/juce-dev:build</code>) also works on Windows and Linux if you're running Claude Code there — it detects the platform and uses the appropriate build script. Visage is fully cross-platform: Metal on macOS, Direct3D11 on Windows, Vulkan on Linux.</p>
                         </div>
                     </div>
                     <div class="faq-item">
                         <div class="faq-question" onclick="toggleFaq(this)">How does the port command work?</div>
                         <div class="faq-answer">
-                            <p>The port command currently supports porting <strong>from macOS to Windows</strong>. It scans for macOS-specific code and applies Windows-compatible fixes. It runs through four stages:</p>
-                            <p><strong>1. Audit</strong> — scans every source file, CMakeLists.txt, and build script for macOS-only patterns (Objective-C++, Cocoa/AppKit imports, CoreAudio/CoreMIDI, macOS bundle paths, etc.). Categorizes each finding by severity (HIGH: <code>.mm</code> files, Cocoa imports; MEDIUM: macOS-specific paths; LOW: Unix-only headers). Use <code>--audit-only</code> to see the report without making changes.</p>
+                            <p>The port command supports porting <strong>between macOS and Windows</strong> in either direction. It auto-detects your source platform and scans for the right patterns. It runs through four stages:</p>
+                            <p><strong>1. Audit</strong> — detects your source platform and scans for platform-specific code. <em>macOS → Windows:</em> finds Objective-C++, Cocoa/AppKit imports, CoreAudio/CoreMIDI, macOS paths. <em>Windows → macOS:</em> finds Win32 API calls (<code>HWND</code>, <code>CreateWindow</code>), COM interfaces, DirectX headers, MSVC pragmas, Windows registry access, <code>.dll</code>/<code>.exe</code> references. Categorizes by severity. Use <code>--audit-only</code> for just the report.</p>
                             <p><strong>2. Plan</strong> — shows you the full list of changes and asks whether to apply all at once, go through them one by one, or export a plan to a markdown file.</p>
-                            <p><strong>3. Execute</strong> — creates a <code>port/windows</code> branch and applies fixes: CMake platform conditionals, <code>#if JUCE_MAC</code> guards, MSVC compile flags, <code>if(APPLE)</code> guards for AU/AUv3 formats, and Windows build scripts.</p>
-                            <p><strong>4. Test</strong> — optionally SSHs to your VM, pushes the branch, runs the build there, and reports back. If the build fails, it analyzes the errors, fixes locally, pushes again, and retries. You can also trigger GitHub Actions CI instead.</p>
+                            <p><strong>3. Execute</strong> — creates a <code>port/&lt;platform&gt;</code> branch and applies fixes. <em>To Windows:</em> CMake conditionals, <code>#if JUCE_MAC</code> guards, MSVC flags, Windows build scripts. <em>To macOS:</em> <code>#if JUCE_WINDOWS</code> guards, AU/AUv3 format support, universal binary config (<code>arm64;x86_64</code>), code signing/notarization setup, macOS build scripts, Xcode project generation.</p>
+                            <p><strong>4. Test</strong> — optionally SSHs to your target VM, pushes the branch, runs the build there, and reports back. For macOS targets, also validates AU plugins with <code>auval</code>. If the build fails, it analyzes errors, fixes locally, pushes again, and retries. You can also trigger GitHub Actions CI instead.</p>
                             <p>Your project needs to be cloned on the VM as well — the port command pushes your branch to GitHub and pulls it on the VM via SSH.</p>
                         </div>
                     </div>
                     <div class="faq-item">
                         <div class="faq-question" onclick="toggleFaq(this)">How do I set up a VM for cross-platform testing?</div>
                         <div class="faq-answer">
-                            <p>You need SSH access to a Windows or Linux machine (a VM, a remote server, or another computer on your network). Add an SSH config entry in <code>~/.ssh/config</code>:</p>
+                            <p>You need SSH access to the target machine (a VM, a remote server, or another computer on your network). Add an SSH config entry in <code>~/.ssh/config</code>:</p>
                             <div class="code-block-wrapper">
                                 <button class="copy-btn" onclick="copyCode(this)">Copy</button>
                                 <div class="code-block" style="white-space: pre; line-height: 1.6;"><span class="code-comment"># ~/.ssh/config</span>
@@ -960,19 +969,34 @@ Host windows10
   User joesmith
   IdentityFile ~/.ssh/id_ed25519
   IdentitiesOnly yes
+  ConnectTimeout 5
+
+Host macmini
+  HostName 192.168.20.40
+  User joesmith
+  IdentityFile ~/.ssh/id_ed25519
+  IdentitiesOnly yes
   ConnectTimeout 5</div>
                             </div>
-                            <p style="margin-top: 1rem;">Then register it with juce-dev:</p>
+                            <p style="margin-top: 1rem;">Then register VMs with juce-dev:</p>
                             <div class="code-block-wrapper">
                                 <button class="copy-btn" onclick="copyCode(this)">Copy</button>
                                 <div class="code-block"><span class="code-prompt">/</span>juce-dev:vm add windows10 windows10 windows</div>
+                            </div>
+                            <div style="margin-top: 0.5rem;" class="code-block-wrapper">
+                                <button class="copy-btn" onclick="copyCode(this)">Copy</button>
+                                <div class="code-block"><span class="code-prompt">/</span>juce-dev:vm add macmini macmini macos</div>
                             </div>
                             <p style="margin-top: 1rem;">Now you can port and test in one step:</p>
                             <div class="code-block-wrapper">
                                 <button class="copy-btn" onclick="copyCode(this)">Copy</button>
                                 <div class="code-block"><span class="code-prompt">/</span>juce-dev:port windows --vm windows10</div>
                             </div>
-                            <p style="margin-top: 0.5rem;">The port command will SSH to your VM, pull the branch, build with MSVC + Ninja, and report results. Your project repo needs to be cloned on the VM — the command pushes your branch to GitHub and pulls it remotely.</p>
+                            <div style="margin-top: 0.5rem;" class="code-block-wrapper">
+                                <button class="copy-btn" onclick="copyCode(this)">Copy</button>
+                                <div class="code-block"><span class="code-prompt">/</span>juce-dev:port macos --vm macmini</div>
+                            </div>
+                            <p style="margin-top: 0.5rem;">The port command will SSH to your VM, pull the branch, build with the platform's toolchain, and report results. For macOS targets, it also validates AU plugins with <code>auval</code>. Your project repo needs to be cloned on the VM — the command pushes your branch to GitHub and pulls it remotely.</p>
                             <p>Use <code>/juce-dev:vm list</code> to see configured VMs, or <code>/juce-dev:status</code> for a full project overview.</p>
                         </div>
                     </div>


### PR DESCRIPTION
## Summary

- Adds bidirectional port support to `/juce-dev:port` — now supports Windows → macOS in addition to existing macOS → Windows/Linux
- Updates `index.html` homepage to reflect bidirectional port capability across all relevant sections

## Test plan

- [x] All 40+ Windows-specific scan patterns validated against simulated Windows-origin JUCE project
- [x] Platform auto-detection correctly identifies Windows-origin projects (build.ps1, Azure signing, no .mm files)
- [x] Visage correctly NOT flagged as platform-specific (cross-platform via bgfx)
- [x] FetchContent dependencies correctly NOT flagged
- [ ] Human review of port.md command structure and completeness
- [ ] Human review of index.html wording and layout

Closes #1